### PR TITLE
NPE when ensime file dialog is cancelled

### DIFF
--- a/src/main/scala/com/codecommit/es/EnsimePlugin.scala
+++ b/src/main/scala/com/codecommit/es/EnsimePlugin.scala
@@ -72,76 +72,77 @@ object EnsimePlugin {
       
       EventQueue.invokeLater(new Runnable {
         def run() {
-          val projectFileName = JOptionPane.showInputDialog(view, "ENSIME Project File:", projectPath)
-          val projectFile = new File(projectFileName)
-          
-          if (projectFile.exists) {
-            val src = Source fromFile projectFile
-            val optProjectData = Option(SExp.read(new CharSequenceReader(src.mkString)))
-            
-            if (!optProjectData.isDefined) {
-              JOptionPane.showMessageDialog(view, "Project file is invalid.  Make sure it consists of a single s-expression.  (no comments!)", "Error", JOptionPane.ERROR_MESSAGE)
-            }
-            
-            for (projectData @ SExpList(data) <- optProjectData) {
-              val optSubprojectItems = projectData.toKeywordMap.get(SExp.key(":sbt-subprojects")) collect { case SExpList(items) => Vector(items.toList: _*) }
-              val optSubprojects = optSubprojectItems map { _ collect { case xs: SExpList => xs.toKeywordMap } map { _(SExp.key(":name")) } collect { case StringAtom(str) => str } }
-              
-              val optActiveSubproject = optSubprojects flatMap { subprojects =>
-                val dialog = new ui.SubprojectSelectorDialog(view, subprojects)
-                dialog.open()
-              }
-              
-              if (!optSubprojects.isDefined || optActiveSubproject.isDefined) {
-                val parentDir = projectFile.getParentFile
-                val projectData2 = SExpList(
-                  SExp.key(":root-dir") :: StringAtom(parentDir.getCanonicalPath) ::
-                  (optActiveSubproject map { str => SExp.key(":sbt-active-subproject") :: StringAtom(str) :: data.toList } getOrElse data.toList))
-                
-                val home = projectData2.toKeywordMap get SExp.key(":ensime-home") collect { case StringAtom(str) => str } map { new File(_) } filter { _.exists } getOrElse EnsimeHome
-                
-                view.getStatus.setMessage("ENSIME: Starting server...")
-                
-                val inst = new Instance(parentDir, home) { self =>
-                  def fatalServerError(msg: String) {
-                    EventQueue.invokeLater(new Runnable {
-                      def run() {
-                        JOptionPane.showMessageDialog(view, "ENSIME: Fatal Error!  " + msg, "Error", JOptionPane.ERROR_MESSAGE)
-                      }
-                    })
-                    
-                    lock synchronized {
-                      for ((root, `self`) <- instances) {
-                        instances -= root
-                      }
-                    }
-                    
-                    self.stop()
-                  }
-                }
-                
-                inst.start("SBT_OPTS" -> SbtOpts)
-                inst.Ensime.initProject(projectData2) { (projectName, sourceRoots) =>
-                  if (sourceRoots.isEmpty) {
-                    EventQueue.invokeLater(new Runnable {
-                      def run() {
-                        JOptionPane.showMessageDialog(view, "ENSIME failed to start!  Could not detect source roots.", "Error", JOptionPane.ERROR_MESSAGE)
-                      }
-                    })
-                    inst.stop()
-                  } else {
-                    lock synchronized {
-                      sourceRoots foreach { root => instances += (root -> inst) }
-                    }
-                  }
-                }
-              }
-            }
-          } else {
-            JOptionPane.showMessageDialog(view, "Specified project file does not exist!", "Error", JOptionPane.ERROR_MESSAGE)
-          }
+          for {
+            n <- Option(JOptionPane.showInputDialog(view, "ENSIME Project File:", projectPath))
+          } Some(new File(n)).filter(_.exists)
+              .map(initProjectFile)
+              .getOrElse(JOptionPane.showMessageDialog(view, "Specified project file does not exist!", "Error", JOptionPane.ERROR_MESSAGE))
         }
       })
+    }
+    
+    def initProjectFile(projectFile: File) = {
+      val src = Source fromFile projectFile
+      val optProjectData = Option(SExp.read(new CharSequenceReader(src.mkString)))
+      
+      if (!optProjectData.isDefined) {
+        JOptionPane.showMessageDialog(view, "Project file is invalid.  Make sure it consists of a single s-expression.  (no comments!)", "Error", JOptionPane.ERROR_MESSAGE)
+      }
+      
+      for (projectData @ SExpList(data) <- optProjectData) {
+        val optSubprojectItems = projectData.toKeywordMap.get(SExp.key(":sbt-subprojects")) collect { case SExpList(items) => Vector(items.toList: _*) }
+        val optSubprojects = optSubprojectItems map { _ collect { case xs: SExpList => xs.toKeywordMap } map { _(SExp.key(":name")) } collect { case StringAtom(str) => str } }
+        
+        val optActiveSubproject = optSubprojects flatMap { subprojects =>
+          val dialog = new ui.SubprojectSelectorDialog(view, subprojects)
+          dialog.open()
+        }
+        
+        if (!optSubprojects.isDefined || optActiveSubproject.isDefined) {
+          val parentDir = projectFile.getParentFile
+          val projectData2 = SExpList(
+            SExp.key(":root-dir") :: StringAtom(parentDir.getCanonicalPath) ::
+            (optActiveSubproject map { str => SExp.key(":sbt-active-subproject") :: StringAtom(str) :: data.toList } getOrElse data.toList))
+          
+          val home = projectData2.toKeywordMap get SExp.key(":ensime-home") collect { case StringAtom(str) => str } map { new File(_) } filter { _.exists } getOrElse EnsimeHome
+          
+          view.getStatus.setMessage("ENSIME: Starting server...")
+          
+          val inst = new Instance(parentDir, home) { self =>
+            def fatalServerError(msg: String) {
+              EventQueue.invokeLater(new Runnable {
+                def run() {
+                  JOptionPane.showMessageDialog(view, "ENSIME: Fatal Error!  " + msg, "Error", JOptionPane.ERROR_MESSAGE)
+                }
+              })
+              
+              lock synchronized {
+                for ((root, `self`) <- instances) {
+                  instances -= root
+                }
+              }
+              
+              self.stop()
+            }
+          }
+          
+          inst.start("SBT_OPTS" -> SbtOpts)
+          inst.Ensime.initProject(projectData2) { (projectName, sourceRoots) =>
+            if (sourceRoots.isEmpty) {
+              EventQueue.invokeLater(new Runnable {
+                def run() {
+                  JOptionPane.showMessageDialog(view, "ENSIME failed to start!  Could not detect source roots.", "Error", JOptionPane.ERROR_MESSAGE)
+                }
+              })
+              inst.stop()
+            } else {
+              lock synchronized {
+                sourceRoots foreach { root => instances += (root -> inst) }
+              }
+            }
+          }
+        }
+      }
     }
   }
   


### PR DESCRIPTION
Hi Daniel,

This is a fix for the aforementioned issue, minor as it is. I'm trying to root out a problem with ensime starting, which at the moment seems quite non-deterministic (watching the activity log revealed the NPE). I took the liberty to breaking up initProject in an effort to avoid another nested if; I hope you don't mind.

Thanks for the great work! I'm a long time jEdit user and a more intelligent scala environment is something I'm happy to assist.

-chris
